### PR TITLE
y* packages als abhängigkeiten deklarieren, sodass phpstan die klasse…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,10 @@
     },
     "require-dev": {
         "redaxo/source": "^5.11",
-        "phpstan/phpstan": "0.12.52"
+        "phpstan/phpstan": "0.12.52",
+        "yakamara/redaxo_yform": "dev-master",
+        "yakamara/redaxo_ycom": "dev-master",
+        "yakamara/redaxo_yrewrite": "dev-master"
     },
     "scripts": {
         "phpstan": "phpstan analyse",


### PR DESCRIPTION
…n kennt

Todo
- [ ] merge https://github.com/yakamara/redaxo_ycom/pull/342
- [ ] merge https://github.com/yakamara/redaxo_yrewrite/pull/369
- [ ] ycom auf packagist.org registrieren
- [ ] yform auf packagist.org registrieren
- [ ] yrewrite auf packagist.org registrieren
- [ ] wenn alle anderen todos erledigt sind -> `composer phpstan-baseline` ausführen und die baseline neu committen