### PR TITLE
`/phpstan-baseline` chatops command erstellt

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -14,5 +14,5 @@ jobs:
           token: ${{ secrets.STAABM_TOKEN }}
           # reactions should be reported from github itself
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          commands: csfix, phpstan-baseline
+          commands: phpstan-baseline
           issue-type: pull-request

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,18 @@
+name: Chatops
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash-command-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.STAABM_TOKEN }}
+          # reactions should be reported from github itself
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: csfix, phpstan-baseline
+          issue-type: pull-request

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,6 +3,8 @@ name: PHP Checks
 on:
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
+    repository_dispatch:
+        types: [phpstan-baseline-command] # triggered by /phpstan-baseline PR comment
 
 jobs:
 
@@ -11,14 +13,43 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: 7.4
-                  extensions: intl, imagick
-                  coverage: none # disable xdebug, pcov
-            - name: Install Dependencies
-              run: composer install --ansi --prefer-dist
-            - run: |
-                  vendor/bin/phpstan analyse --ansi --no-progress
+        - name: Add action run link to trigger comment
+          if: "github.event_name == 'repository_dispatch'"
+          uses: peter-evans/create-or-update-comment@v1
+          with:
+            token: ${{ secrets.STAABM_TOKEN }}
+            repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+            comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+            body: |
+              ```
+              https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              ```
+
+        - uses: actions/checkout@v2
+          with:
+            token: ${{ secrets.STAABM_TOKEN }}
+            repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+            ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: 7.4
+              extensions: intl, imagick
+              coverage: none # disable xdebug, pcov
+
+        - name: Install Dependencies
+          run: composer install --ansi --prefer-dist
+
+        - run: composer phpstan-baseline # generate baseline
+          if: "github.event_name == 'repository_dispatch'"
+        - name: Commit changed files
+          if: "github.event_name == 'repository_dispatch'"
+          uses: stefanzweifel/git-auto-commit-action@v4
+          with:
+            commit_message: Apply phpstan-baseline changes
+            branch: ${{ github.head_ref }}
+            file_pattern: '*.neon'
+
+        - run: vendor/bin/phpstan analyse --ansi --no-progress
+          if: "github.event_name != 'repository_dispatch'"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "yakamara/redaxo_yrewrite": "dev-master"
     },
     "scripts": {
+        "update-deps": "@composer update --no-dev",
         "phpstan": "phpstan analyse",
-        "phpstan-baseline": "phpstan analyse --generate-baseline"
+        "phpstan-baseline": "phpstan analyse --generate-baseline",
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     "scripts": {
         "update-deps": "@composer update --no-dev",
         "phpstan": "phpstan analyse",
-        "phpstan-baseline": "phpstan analyse --generate-baseline",
+        "phpstan-baseline": "phpstan analyse --generate-baseline"
     }
 }


### PR DESCRIPTION
Idee:

- phpstan handling passiert nur noch in den Pull Requests, nicht mehr lokal. d.h. um eine baseline neu in einem pull-request zu generieren schreibt man im Pull Request den kommentar `/phpstan-baseline`. dadurch wird eine GitHub Action getriggert, die die baseline neu generiert (alle errors die im PR noch vorhanden sind, landen auf der ignore-list bzw. errors die ggf. nicht mehr vorhanden sind werden aus der baseline entfernt).

- um lokal Composer Abhängigkeiten zu aktualisieren benutzt man das composer script: `composer update-deps`. dabei werden nur die echten aber nicht die dev-abhängigkeiten updated. Somit erhält man einen sauberen stand zum committen, ohne dev-tools

closes https://github.com/FriendsOfREDAXO/simple_saml/issues/5


Ausblick: bei uns in der Firma haben wir u.a. auch chat commands um den CSFIXER zu triggern, oder um commits zwischen branches hin und her zu mergen